### PR TITLE
Export SVG icons as files instead of inline svg

### DIFF
--- a/config/webpack.config.prod.babel.js
+++ b/config/webpack.config.prod.babel.js
@@ -85,9 +85,12 @@ const config = {
         ],
       },
       {
+        // load media files - need to be injected without a prefixing slash
         test: /\.svg$/,
-        loader: 'svg-inline-loader',
-      },
+        use: [
+          'file-loader?name=icons/[name].[ext]',
+        ],
+      }
     ],
   },
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "classnames": "^2.2.5",
+    "is-svg": "^2.1.0",
     "prop-types": "^15.6.0"
   },
   "main": "./dist/js/bundle.js",

--- a/src/assets/icons/fa.js
+++ b/src/assets/icons/fa.js
@@ -11,7 +11,9 @@ export { default as alignLeft } from './fa/align-left.svg';
 export { default as alignRight } from './fa/align-right.svg';
 export { default as amazon } from './fa/amazon.svg';
 export { default as ambulance } from './fa/ambulance.svg';
-export { default as americanSignLanguageInterpreting } from './fa/american-sign-language-interpreting.svg';
+export {
+  default as americanSignLanguageInterpreting
+} from './fa/american-sign-language-interpreting.svg';
 export { default as anchorIcon } from './fa/anchor.svg';
 export { default as android } from './fa/android.svg';
 export { default as angellist } from './fa/angellist.svg';

--- a/src/components/Icon/index.jsx
+++ b/src/components/Icon/index.jsx
@@ -2,27 +2,23 @@
 
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import * as ICONS from '../../assets/icons';
+import classnames from 'classnames';
+import isSVG from 'is-svg';
+
 import './style.scss';
 
 class Icon extends PureComponent {
-  getClass() {
-    const classes = ['Van-Icon'];
-
-    if (this.props.className) {
-      classes.push(this.props.className);
-    }
-
-    return classes.join(' ').trim();
-  }
-
   render() {
     const { className, source, ...props } = this.props;
 
+    if (!isSVG(source)) {
+      return null;
+    }
+
     return (
       <span
-        className={this.getClass()}
-        dangerouslySetInnerHTML={{ __html: ICONS[source] }}
+        className={classnames('Van-Icon', className)}
+        dangerouslySetInnerHTML={{ __html: source }}
         {...props}
       />
     );

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import './assets/icons';
+
 export { default as indexStyles } from './index.scss';
 
 if (process.env.NODE_ENV === 'development') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3768,7 +3768,7 @@ is-supported-regexp-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz#8b520c85fae7a253382d4b02652e045576e13bb8"
 
-is-svg@^2.0.0:
+is-svg@^2.0.0, is-svg@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-2.1.0.tgz#cf61090da0d9efbcab8722deba6f032208dbb0e9"
   dependencies:


### PR DESCRIPTION
From now on you need to import the Icon component and also the icon's SVG file using `svg-inline-loader`, doing this change, it'll reduce the bundle size because it's no longer necessary to import all icons, just the icons that are being used.

It's needed to update the webpack.confg.js from the project that is using vandebron-styleguide as dependency
```js
{
  // load media files - ignoring files which starts with vandebron-styleguide
  test: /(^(?!.*\bvandebron-styleguide\b)(.)*svg$|\.woff|\.eot|\.ttf|\.png|\.gif|\.jpg)/,
  use: [
    "file-loader?name=static/media/[name].[hash:8].[ext]"
  ]
},
{
  // inline load vandebron-styleguide icons  
  test: /vandebron-styleguide(.)*svg$/,
  loader: 'svg-inline-loader'
}
```

my-component.js
```jsx
import { Icon } from 'vandebron-styleguide';
import sunIcon from 'vandebron-styleguide/dist/icons/sun.svg';

<Icon source={sunIcon} />
```