### PR TITLE
[Button] Make button act like a link

### DIFF
--- a/catalog/pages/elements/buttons.md
+++ b/catalog/pages/elements/buttons.md
@@ -87,6 +87,13 @@
   <Button theme="primary" full>Full button</Button>
 ```
 
+### Link
+Make button act like a link.
+
+```react
+<Button theme="primary" href="https://vandebron.nl" target="_blank" link>Big link</Button>
+```
+
 
 ### API
 

--- a/src/components/Button/__tests__/__snapshots__/index.test.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/index.test.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Button> renders a link 1`] = `
+<a
+  className="Van-Button"
+  href="https://vandebron.nl"
+>
+  Button link
+</a>
+`;
+
 exports[`<Button> renders big button size 1`] = `
 <button
   className="Van-Button Van-Button--big"

--- a/src/components/Button/__tests__/index.test.js
+++ b/src/components/Button/__tests__/index.test.js
@@ -194,4 +194,12 @@ describe("<Button>", () => {
 
     expect(tree).toMatchSnapshot();
   });
+
+  it("renders a link", () => {
+    const tree = renderer.create(
+      <Button link href="https://vandebron.nl">Button link</Button>
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -13,12 +13,15 @@ class Button extends PureComponent {
       inverted,
       shape,
       grayscale,
+      link,
       children,
       ...props
     } = this.props;
 
+    const CustomTag = link ? 'a' : 'button';
+
     return (
-      <button
+      <CustomTag
         className={classnames('Van-Button', className, {
           'Van-Button--primary': theme === 'primary',
           'Van-Button--info': theme === 'info',
@@ -54,7 +57,7 @@ class Button extends PureComponent {
                 )
             )
           : children}
-      </button>
+      </CustomTag>
     );
   }
 }
@@ -67,6 +70,7 @@ Button.defaultProps = {
   inverted: false,
   grayscale: false,
   shape: '',
+  link: false,
   children: ''
 };
 
@@ -78,6 +82,7 @@ Button.propTypes = {
   inverted: PropTypes.bool,
   grayscale: PropTypes.bool,
   shape: PropTypes.oneOf(['', 'square', 'circle']),
+  link: PropTypes.bool,
   children: PropTypes.node
 };
 

--- a/src/components/Button/style.scss
+++ b/src/components/Button/style.scss
@@ -14,6 +14,7 @@
   white-space: nowrap;
   padding: 0 15px;
   margin: 0;
+  text-decoration: none;
   cursor: pointer;
   transition: background-color 100ms ease-in-out, border-color 100ms ease-in-out, color 100ms ease-in-out;
   border-radius: 5px;


### PR DESCRIPTION
Make button act like a link, if you pass `link` property it'll render the tag `a` instead of a `button`