### PR TITLE
[Global] Remove font-weight rule from generic selector

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -26,7 +26,6 @@
 
   &[class^="Van-"] {
     font-family: "Proxima Nova", sans-serif;
-    font-weight: $font-weight-light;
     line-height: initial;
   }
 }


### PR DESCRIPTION
Removes font-weight rule from `&[class^="Van-"]` selector, because it's overriding button's font-weight when `Icon` is present.

<img width="465" alt="screen shot 2018-05-02 at 3 46 57 pm" src="https://user-images.githubusercontent.com/1280255/39526759-1137dbec-4e20-11e8-9f58-59db00c3d5a9.png">
