### PR TITLE
[PhoneCard] Change number/description property type

### DIFF
--- a/src/components/PhoneCard/index.jsx
+++ b/src/components/PhoneCard/index.jsx
@@ -40,8 +40,8 @@ PhoneCard.defaultProps = {
 PhoneCard.propTypes = {
   withBorder: PropTypes.bool,
   className: PropTypes.string,
-  number: PropTypes.string,
-  description: PropTypes.string
+  number: PropTypes.node,
+  description: PropTypes.node
 };
 
 export default PhoneCard;


### PR DESCRIPTION
Change `number`/`description` property type to accept a `node` instead of a `string`