### PR TITLE
Fix fill color of the icon inside of an inactive header item

### DIFF
--- a/src/components/DashboardHeader/styles.scss
+++ b/src/components/DashboardHeader/styles.scss
@@ -206,7 +206,7 @@
       border-color: $color-grey-bright;
 
       > .Van-DashboardHeaderDropdownEntry-iconWrapper svg {
-        color: $color-grey-nobel;
+        fill: $color-grey-nobel;
       }
 
       > .Van-DashboardHeaderDropdownEntry-option {


### PR DESCRIPTION
![screen shot 2018-08-29 at 15 11 54](https://user-images.githubusercontent.com/1175594/44789837-eaa99e80-ab9d-11e8-8f12-544f47612c2e.png)
